### PR TITLE
Fix context error handling in crawler

### DIFF
--- a/crawler/crawler.go
+++ b/crawler/crawler.go
@@ -279,11 +279,14 @@ func (c *Crawler) fetchLocalSubscription(ctx context.Context, sub *cfg.Subscript
 		// to maintain a consistent signature with fetchURLSubscription.
 		return fd, http.StatusOK, nil
 	case <-ctx.Done():
-		err = c.ctx.Err()
+		// use the derived context error to provide accurate reason
+		err = ctx.Err()
 
 		// if we return error, the file will not be closed, do it here obviously
-		if closeErr := fd.Close(); closeErr != nil {
-			err = errors.Join(err, closeErr)
+		if fd != nil {
+			if closeErr := fd.Close(); closeErr != nil {
+				err = errors.Join(err, closeErr)
+			}
 		}
 
 		return nil, 0, fmt.Errorf("open file=%q context error: %w", fileName, err)


### PR DESCRIPTION
## Summary
- handle context cancellation correctly when fetching local files
- avoid panic when file descriptor is nil

## Testing
- `go test ./...` *(fails: forbidden download)*
- `make lint` *(fails: forbidden download)*

------
https://chatgpt.com/codex/tasks/task_e_684878ddff24833095ad7e10131be536